### PR TITLE
Allow peer identities to be learned on CEA

### DIFF
--- a/diameter.gemspec
+++ b/diameter.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '0.9' 
   s.add_development_dependency 'mocha', '1.1'
   s.add_development_dependency 'minitest-spec-context', '0.0.3'
+  s.add_development_dependency 'minitest', '5.8.0'
 end

--- a/lib/diameter/peer.rb
+++ b/lib/diameter/peer.rb
@@ -25,8 +25,9 @@ module Diameter
     attr_accessor :identity, :static, :cxn, :realm, :expiry_time, :last_message_seen
     attr_reader :state
 
-    def initialize(identity)
+    def initialize(identity, realm)
       @identity = identity
+      @realm = realm
       @state = :CLOSED
       @state_change_q = Queue.new
     end

--- a/lib/diameter/stack.rb
+++ b/lib/diameter/stack.rb
@@ -389,7 +389,7 @@ module Diameter
         @peer_table[host].state = :UP
         @peer_table[host].reset_timer
       else
-        entry = @peer_table.find { |h, p| p.cxn = cxn }
+        entry = @peer_table.find { |h, p| p.cxn == cxn }
         if entry.nil?
           Diameter.logger.warn("Ignoring CEA from unknown peer #{peer}")
           Diameter.logger.debug("Known peers are #{@peer_table.keys}")

--- a/lib/diameter/stack.rb
+++ b/lib/diameter/stack.rb
@@ -188,9 +188,11 @@ module Diameter
     #
     # @param req [Message] The request to send.
     # @param peer [Peer] (Optional) A peer to use as the first hop for the message
-    def send_request(req, peer: nil)
+    def send_request(req, options={})
       fail "Must pass a request" unless req.request
       req.add_origin_host_and_realm(@local_host, @local_realm)
+
+      peer = options[:peer]
 
       if peer.nil?
         peer = if req['Destination-Host']

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -24,7 +24,7 @@ else
 end
 
 # Compatability with minitest/autorun
-Concurrent.configuration.auto_terminate = false
+Concurrent.disable_at_exit_handlers!
 
-Concurrent.configuration.logger = Proc.new { |level, progname, message = nil, &block| Diameter.logger.debug(message) }
+Concurrent.global_logger = Proc.new { |level, progname, message = nil, &block| Diameter.logger.debug(message) }
 

--- a/test/test_server_stack.rb
+++ b/test/test_server_stack.rb
@@ -47,6 +47,7 @@ describe 'A server DiameterStack' do
     @s.peer_state('bob').must_equal :CLOSED
 
     avps = [AVP.create('Origin-Host', 'bob'),
+            AVP.create('Origin-Realm', 'bob-realm'),
             AVP.create("Vendor-Specific-Application-Id",
                        [AVP.create("Vendor-Id", @vendor_1),
                         AVP.create("Auth-Application-Id", @vendor_auth_app_id)])]
@@ -60,6 +61,7 @@ describe 'A server DiameterStack' do
     @s.peer_state('bob').must_equal :CLOSED
 
     avps = [AVP.create('Origin-Host', 'bob'),
+            AVP.create('Origin-Realm', 'bob-realm'),
             AVP.create("Vendor-Specific-Application-Id",
                        [AVP.create("Vendor-Id", @vendor_1),
                         AVP.create("Auth-Application-Id", @vendor_auth_app_id)]),]
@@ -83,6 +85,7 @@ describe 'A server DiameterStack' do
       @s.peer_state('bob').must_equal :CLOSED
 
       avps = [AVP.create('Origin-Host', 'bob'),
+              AVP.create('Origin-Realm', 'bob-realm'),
               AVP.create('Auth-Application-Id', @acct_app_id_1 - 6)]
 
       Internals::TCPStackHelper.any_instance.expects(:send)
@@ -103,6 +106,7 @@ describe 'A server DiameterStack' do
       @s.peer_state('bob').must_equal :CLOSED
 
       avps = [AVP.create('Origin-Host', 'bob'),
+              AVP.create('Origin-Realm', 'bob-realm'),
               AVP.create("Vendor-Specific-Application-Id",
                          [AVP.create("Vendor-Id", @vendor_1),
                           AVP.create("Auth-Application-Id", @vendor_auth_app_id)]),
@@ -117,6 +121,7 @@ describe 'A server DiameterStack' do
       @s.peer_state('bob').must_equal :CLOSED
 
       avps = [AVP.create('Origin-Host', 'bob'),
+              AVP.create('Origin-Realm', 'bob-realm'),
               AVP.create('Auth-Application-Id', @vendor_auth_app_id)]
       
       @s.handle_message(make_cer(avps), nil)
@@ -139,6 +144,7 @@ describe 'A server DiameterStack with an existing connection' do
     @s.start
 
     avps = [AVP.create('Origin-Host', 'bob'),
+            AVP.create('Origin-Realm', 'bob-realm'),
             AVP.create('Auth-Application-Id', @auth_app_id)]
     @s.handle_message(make_cer(avps), @bob_socket_id)
 
@@ -157,6 +163,7 @@ describe 'A server DiameterStack with an existing connection' do
     
     avps = [AVP.create("Auth-Application-Id", @auth_app_id),
             AVP.create('Origin-Host', 'bob'),
+            AVP.create('Origin-Realm', 'bob-realm'),
             AVP.create("Destination-Host", "rkd2.local"),
             AVP.create("Destination-Realm", "my-realm")]
 
@@ -176,6 +183,7 @@ describe 'A server DiameterStack with an existing connection' do
     
     avps = [AVP.create("Auth-Application-Id", @auth_app_id),
             AVP.create('Origin-Host', 'bob'),
+            AVP.create('Origin-Realm', 'bob-realm'),
             AVP.create("Destination-Host", "rkd2.local"),
             AVP.create("Destination-Realm", "my-realm")]
 


### PR DESCRIPTION
This allows clients to connect to peers without knowing their Origin-Host, which is a first step in allowing fully dynamic realm discovery.

Also allows multiple peers per realm (and load-balances messages to them if Destination-Host is not set).