### PR TITLE
Fix race between CEA and connect_to_peer return

### DIFF
--- a/lib/diameter/stack.rb
+++ b/lib/diameter/stack.rb
@@ -159,7 +159,8 @@ module Diameter
     # @param realm [String] The Diameter realm of this peer.
     # @return [Peer] The Diameter peer chosen.
     def connect_to_peer(peer_uri, peer_host, realm)
-      @peer_table[peer_host] = Peer.new(peer_host, realm)
+      peer = Peer.new(peer_host, realm)
+      @peer_table[peer_host] = peer
       @peer_table[peer_host].state = :WAITING
       # Will move to :UP when the CEA is received
 
@@ -177,7 +178,7 @@ module Diameter
       cer_bytes = Message.new(version: 1, command_code: 257, app_id: 0, request: true, proxyable: false, retransmitted: false, error: false, avps: avps).to_wire
       @tcp_helper.send(cer_bytes, cxn)
 
-      @peer_table[peer_host]
+      peer
     end
 
     # Sends a Diameter request. This is routed to an appropriate peer


### PR DESCRIPTION
Hi @rkday. I think I've found a race condition in your otherwise fantastic Diameter library.

handle_cea sometimes changes the name of a peer, and if it manages to do that before we return from connect_to_peer (which does seem kind of impressive, but I'm pretty sure I've seen it happen occasionally) then connect_to_peer will return null.